### PR TITLE
Core 10934 attachments streaming

### DIFF
--- a/email.go
+++ b/email.go
@@ -379,7 +379,7 @@ func streamToBytes(r io.Reader) (b []byte, err error) {
 	return buffer.Bytes(), nil
 }
 
-func (e *Email) bytesNoAttachments() ([]byte, error) {
+func (e *Email) BytesNoAttachments() ([]byte, error) {
 	// TODO: better guess buffer size
 	buff := bytes.NewBuffer(make([]byte, 0, 4096))
 

--- a/email.go
+++ b/email.go
@@ -865,6 +865,16 @@ func (at *Attachment) setDefaultHeaders() {
 	}
 }
 
+func (at *Attachment) Stream(w io.Writer) error {
+	// TODO: here will be method for Attachment self-streaming with boundaries in base64
+	return nil
+}
+
+func base64stream(r io.Reader, w io.Writer) error {
+	// TODO: here will be method for base64 streaming of attachment self
+	return nil
+}
+
 // base64Wrap encodes the attachment content, and wraps it according to RFC 2045 standards (every 76 chars)
 // The output is then written to the specified io.Writer
 func base64Wrap(w io.Writer, b []byte) {

--- a/email_test.go
+++ b/email_test.go
@@ -717,13 +717,19 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.Attachments[0].Filename != a.Filename {
 		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[0].Filename, a.Filename)
 	}
-	if !bytes.Equal(e.Attachments[0].Content, a.Content) {
+	var b1, b2 []byte
+	b1, _ = streamToBytes(e.Attachments[0].Content)
+	b2, _ = streamToBytes(a.Content)
+	if !bytes.Equal(b1, b2) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[0].Content, a.Content)
 	}
 	if e.Attachments[1].Filename != b.Filename {
 		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[1].Filename, b.Filename)
 	}
-	if !bytes.Equal(e.Attachments[1].Content, b.Content) {
+	var b3, b4 []byte
+	b3, _ = streamToBytes(e.Attachments[1].Content)
+	b4, _ = streamToBytes(b.Content)
+	if !bytes.Equal(b3, b4) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[1].Content, b.Content)
 	}
 }


### PR DESCRIPTION


This is pre-draft PR.
Not all methods implemented.
Original Attachment structure contains io.Stream instead of []byte now.
Affected functions and tests modified to match changes.
Streaming base64 attachment sending is in development

func (e *Email) bytesNoAttachments() repeats original code from .Bytes() except base64 encoding of attachments
